### PR TITLE
Shorten flyover mobile toast, zoom in flyover one level

### DIFF
--- a/index.html
+++ b/index.html
@@ -1000,7 +1000,7 @@
         var foSmoothLng = 0;
         var foSmoothLat = 0;
         var foSmoothBearing = 0;
-        var foFlyoverZoom = 13;
+        var foFlyoverZoom = 14;
         var foMapViewZoom = 10;
         var foIsMapView = false;
         var foPitch = isMobile ? 30 : 60;
@@ -1383,8 +1383,8 @@
                     var toast = document.getElementById('fo-toast');
                     toast.style.display = '';
                     setTimeout(function () { toast.style.opacity = '1'; }, 100);
-                    setTimeout(function () { toast.style.opacity = '0'; }, 3500);
-                    setTimeout(function () { toast.style.display = 'none'; }, 4000);
+                    setTimeout(function () { toast.style.opacity = '0'; }, 2500);
+                    setTimeout(function () { toast.style.display = 'none'; }, 3000);
                 }
             });
 

--- a/index.html
+++ b/index.html
@@ -259,8 +259,8 @@
 
         .nav-radio-btn {
             display: block;
-            padding: 4px 12px;
-            font-size: 0.75rem;
+            padding: 5px 14px;
+            font-size: 0.8rem;
             color: rgba(255,255,255,0.7);
             text-decoration: none;
             letter-spacing: 0.5px;
@@ -346,7 +346,7 @@
             }
 
             #st-nav { bottom: 16px; }
-            .nav-radio-btn { padding: 4px 12px; font-size: 0.75rem; }
+            .nav-radio-btn { padding: 5px 14px; font-size: 0.8rem; }
         }
 
         /* ────────────────────────────────────
@@ -649,8 +649,8 @@
             #fo-controls .divider { height: 14px; }
 
             #fo-controls .nav-radio .nav-radio-btn {
-                padding: 4px 10px;
-                font-size: 0.7rem;
+                padding: 5px 14px;
+                font-size: 0.8rem;
             }
 
             #fo-mile-counter {


### PR DESCRIPTION
  - Flyover starts one zoom level closer (13 → 14)
  - Shortened flyover mobile 3D toast (3.5s → 2.5s)                                                                                                        
  - Log/Flyover radio buttons bigger to match control button size   